### PR TITLE
sending new post notification - topic url fix

### DIFF
--- a/Src/Dialogue.Logic/Controllers/DialoguePostController.cs
+++ b/Src/Dialogue.Logic/Controllers/DialoguePostController.cs
@@ -137,7 +137,7 @@ namespace Dialogue.Logic.Controllers
                     // Create the email
                     var sb = new StringBuilder();
                     sb.AppendFormat("<p>{0}</p>", string.Format(Lang("Post.Notification.NewPosts"), topic.Name));
-                    sb.AppendFormat("<p>{0}</p>", string.Concat(Settings.ForumRootUrlWithDomain, topic.Url));
+                    sb.AppendFormat("<p>{0}</p>", string.Concat(AppHelpers.ReturnCurrentDomain(), topic.Url));
                     sb.Append(postContent);
 
                     // create the emails only to people who haven't had notifications disabled


### PR DESCRIPTION
During sending new post notification topic url has duplicated forum root node url
