### PR TITLE
46 cannot delete members of type dialogue

### DIFF
--- a/Src/Dialogue.Logic/Services/MemberService.cs
+++ b/Src/Dialogue.Logic/Services/MemberService.cs
@@ -480,8 +480,11 @@
         public void RefreshMemberPosts(Member member, int amount)
         {
             var baseMember = _memberService.GetById(member.Id);
-            baseMember.Properties[AppConstants.PropMemberPostCount].Value = amount;
-            _memberService.Save(baseMember);
+            if (baseMember != null && baseMember.Properties.Contains(AppConstants.PropMemberPostCount))
+            {
+                baseMember.Properties[AppConstants.PropMemberPostCount].Value = amount;
+                _memberService.Save(baseMember);
+            }
         }
 
         public void SyncMembersPostCount(List<Member> members)


### PR DESCRIPTION
fixes issue 46.
Added check to see if member has property postCount before trying to update it.
Delete seems to work on non Dialogue member types now.